### PR TITLE
fix incompatibility of ml-10m with datatable 0.11.1

### DIFF
--- a/rs_datasets/movielens.py
+++ b/rs_datasets/movielens.py
@@ -90,8 +90,8 @@ class MovieLens(Dataset):
     @staticmethod
     def _read_10m(folder: str) -> Tuple[Frame, Frame, Frame]:
         ratings = dt.fread(join(folder, 'ratings.dat'), columns=rating_cols).to_pandas()
-        items = dt.fread(join(folder, 'movies.dat'), columns=item_cols).to_pandas()
-        tags = dt.fread(join(folder, 'tags.dat'), columns=tag_cols).to_pandas()
+        items = dt.fread(join(folder, 'movies.dat'), columns=item_cols, quotechar="").to_pandas()
+        tags = dt.fread(join(folder, 'tags.dat'), columns=tag_cols, quotechar="").to_pandas()
         return ratings, items, tags
 
     @staticmethod


### PR DESCRIPTION
When using `rs_datasets` with `datatable==0.11.1`, loading of MovieLens 10m breaks because of:

line 9811 in `movies.dat`: `51372   "Great Performances" Cats (1998)        Musical`
and line 50208 in `tags.dat`: `33384   2020    "underaged sex"=child porn      1181826527`

It looks like newer `datatable` works with quotation differently.