### PR TITLE
Change a typo in docs

### DIFF
--- a/docs/directory.md
+++ b/docs/directory.md
@@ -6,7 +6,7 @@ Dataset directory is determined by following priorities:
 
 1. `path` parameter from initialization
 2. Environment variable `RS_DATASETS`
-3. Default folder, which is in your home directory: `~/rs_datasets/`
+3. Default folder, which is in your home directory: `~/.rs_datasets/`
 
 So in general case you don't have to do anything 
-and files corresponding to `dataset` will be stored in `~/rs_datasets/dataset/`.
+and files corresponding to `dataset` will be stored in `~/.rs_datasets/dataset/`.


### PR DESCRIPTION
The default folder is `.rs_datasets`, no simply `rs_datasets`